### PR TITLE
Minor additions and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ MANIFEST
 tags
 build
 dist
+*.egg-info
+.eggs
+plot.png

--- a/fgivenx/parallel.py
+++ b/fgivenx/parallel.py
@@ -42,7 +42,8 @@ def parallel_apply(f, array, **kwargs):
         raise TypeError('Unexpected **kwargs: %r' % kwargs)
 
     if not parallel:
-        return [f(*(precurry + (x,) + postcurry)) for x in tqdm.tqdm(array)]
+        return [f(*(precurry + (x,) + postcurry)) for x in
+                tqdm.tqdm_notebook(array, leave=False)]
     elif parallel is True:
         nprocs = cpu_count()
     elif isinstance(parallel, int):
@@ -54,4 +55,5 @@ def parallel_apply(f, array, **kwargs):
         raise ValueError("parallel keyword must be an integer or bool")
 
     return Parallel(n_jobs=nprocs)(delayed(f)(*(precurry + (x,) + postcurry))
-                                   for x in tqdm.tqdm(array))
+                                   for x in tqdm.tqdm_notebook(array,
+                                                               leave=False))

--- a/fgivenx/plot.py
+++ b/fgivenx/plot.py
@@ -1,4 +1,5 @@
 import scipy
+import scipy.ndimage
 import numpy
 import matplotlib.pyplot
 


### PR DESCRIPTION
- error handling for PMF function when samples all have the same value (occurs e.g. when the line you are plotting converges on a single value for some of the x range)
- fixed minor bug in plot.py smoothing (scipy.ndimage not imported)
- made parallel.py use the very nice tqdm_notebook instead of tqdm for progress bars when running in jupyter notebooks. Uses normal tqdm otherwise. Also added option to set the leave parameter in progress bars (defaults to old behaviour).