### PR TITLE
adding tests_require=['pytest'] requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name='fgivenx',
       url='https://github.com/williamjameshandley/fgivenx',
       packages=['fgivenx'],
       install_requires=['numpy','matplotlib','scipy','joblib','tqdm'],
+      tests_require=['pytest'],
       license='MIT',
       classifiers=[
       'Development Status :: 4 - Beta',


### PR DESCRIPTION
I needed this to run the tests as I didn't have it installed. Using tests_require is nice as users who don't want to run the tests don't need to install it.