### PR TITLE
Add histogram support

### DIFF
--- a/fgivenx/mass.py
+++ b/fgivenx/mass.py
@@ -217,7 +217,11 @@ def compute_pmf(fsamps, y, **kwargs):
         raise TypeError('Unexpected **kwargs: %r' % kwargs)
 
     if cache:
-        cache = Cache(cache + '_masses')
+        # Histogram masses are different (in values and shape)
+        if not histogram:
+            cache = Cache(cache + '_masses')
+        else:
+            cache = Cache(cache + '_histogram_masses')
         try:
             return cache.check(fsamps, y)
         except CacheException as e:

--- a/fgivenx/plot.py
+++ b/fgivenx/plot.py
@@ -149,7 +149,7 @@ def plot(x, y, z, ax=None, **kwargs):
     if histogram and pdf_histogram:
         # cmap is reversed for easy compatibility with histogram = False
         cbar = ax.pcolormesh(make_edges(x), y, z, cmap=colors.reversed(), alpha=alpha,
-                             norm=pdf_histogram_norm, **kwargs)
+                             norm=pdf_histogram_norm)
 
 
     # Convert to sigmas
@@ -161,7 +161,7 @@ def plot(x, y, z, ax=None, **kwargs):
         z = scipy.ndimage.gaussian_filter(z, sigma=sigma, order=0)
 
     if histogram and not pdf_histogram:
-        cbar = ax.pcolormesh(make_edges(x), y, z, cmap=colors, alpha=alpha, **kwargs)
+        cbar = ax.pcolormesh(make_edges(x), y, z, cmap=colors, alpha=alpha, vmin=numpy.min(contour_color_levels), vmax=numpy.max(contour_color_levels))
 
     # Plot the filled contours onto the axis ax
     if not histogram:

--- a/fgivenx/plot.py
+++ b/fgivenx/plot.py
@@ -3,6 +3,42 @@ import scipy.ndimage
 import numpy
 import matplotlib.pyplot
 
+def make_edges(x, keep_limits=True):
+    r"""
+    Convert a series of points to a set of bin edges with the points
+    contained within the bins.
+
+    Turn the List
+    X__X____X__X____X____X____X__X____X
+    into the edges
+    |_|___|___|___|____|____|___|___|__|
+
+    Parameters
+    ----------
+    x: numpy array
+        List of points
+
+    keep_limits: bool, optional
+        Whether to make sure the edges are within [min(x), max(x)].
+        If True the first and last bin are smaller to stay within these
+        boundaries, if False they will stretch beyond the limits.
+        Default: True
+
+    Returns
+    -------
+    edges: numpy array
+        bin edges with length `len(x)+1`
+    """
+    diff = numpy.diff(x)
+    edges = x[:-1]+diff/2
+    if keep_limits:
+        edges = numpy.append(edges, x[-1])
+        edges = numpy.insert(edges, 0, x[0])
+    else:
+        edges = numpy.append(edges, x[-1]+diff[-1]/2)
+        edges = numpy.insert(edges, 0, x[0]-diff[0]/2)
+    return edges
+
 
 def plot(x, y, z, ax=None, **kwargs):
     r"""
@@ -11,7 +47,8 @@ def plot(x, y, z, ax=None, **kwargs):
     Parameters
     ----------
     x, y, z : numpy arrays
-        Same as arguments to :func:`matplotlib.pyplot.contour`
+        Same as arguments to :func:`matplotlib.pyplot.contour`, or for
+        histogram to :func:`matplotlib.pyplot.pcolormesh`
 
     ax: axes object, optional
         :class:`matplotlib.axes._subplots.AxesSubplot` to plot the contours
@@ -111,7 +148,7 @@ def plot(x, y, z, ax=None, **kwargs):
 
     if histogram and pdf_histogram:
         # cmap is reversed for easy compatibility with histogram = False
-        cbar = ax.pcolormesh(x, y, z, cmap=colors.reversed(), alpha=alpha,
+        cbar = ax.pcolormesh(make_edges(x), y, z, cmap=colors.reversed(), alpha=alpha,
                              norm=pdf_histogram_norm, **kwargs)
 
 
@@ -124,7 +161,7 @@ def plot(x, y, z, ax=None, **kwargs):
         z = scipy.ndimage.gaussian_filter(z, sigma=sigma, order=0)
 
     if histogram and not pdf_histogram:
-        cbar = ax.pcolormesh(x, y, z, cmap=colors, alpha=alpha, **kwargs)
+        cbar = ax.pcolormesh(make_edges(x), y, z, cmap=colors, alpha=alpha, **kwargs)
 
     # Plot the filled contours onto the axis ax
     if not histogram:

--- a/fgivenx/test/test_drivers.py
+++ b/fgivenx/test/test_drivers.py
@@ -161,9 +161,19 @@ def test_histogram():
 
     # Examine the function over a range of x's
     xmin, xmax = -2, 2
-    nx = 100
-    ny = 96
+    nx = 1000
+    nx_kde = 100
+    ny = 200
+    ny_kde = 100
     x = numpy.linspace(xmin, xmax, nx)
+    x_kde = numpy.linspace(xmin, xmax, nx_kde)
+    samples_kde = samples[::10]
+
+    # Demonstrate nice cmap
+    from matplotlib.colors import ListedColormap, LinearSegmentedColormap
+    level_cmap = LinearSegmentedColormap.from_list('level_cmap',
+                                                   ["red", "orange", "white"],
+                                                   N=5)
 
     # Set the cache
     for cache in [None, 'cache/test']:
@@ -174,9 +184,11 @@ def test_histogram():
         ax_fgivenx.set_ylabel(r'$P(y|x)$')
         ax_fgivenx.set_xlabel(r'$x$')
         cbar = plot_contours(f, x, samples, ax_fgivenx, cache=cache,
-                             histogram=True, ny=10*ny)
-        plot_contours(f, x, samples[::1000], ax_fgivenx, cache=cache, alpha=0,
-                      linewidths=2, ny=ny)
+                             histogram=True, ny=ny, colors=level_cmap,
+                             fineness=1, contour_line_levels=[1,2,3,4,5])
+        plot_contours(f, x_kde, samples_kde, ax_fgivenx, cache=cache,
+                      alpha=0, linewidths=1, ny=ny_kde,
+                      contour_line_levels=[1,2,3,4,5])
         fig.colorbar(cbar, label=r"$\sigma$")
 
         fig, axes = plt.subplots()
@@ -184,7 +196,8 @@ def test_histogram():
         ax_fgivenx.set_ylabel(r'$P(y|x)$')
         ax_fgivenx.set_xlabel(r'$x$')
         cbar = plot_contours(f, x, samples, ax_fgivenx, cache=cache,
-                             pdf_histogram=True, histogram=True, ny=10*ny)
-        plot_contours(f, x, samples[::1000], ax_fgivenx, cache=cache, alpha=0,
-                      linewidths=2, ny=ny)
+                             histogram=True, ny=ny, pdf_histogram=True)
+        plot_contours(f, x_kde, samples_kde, ax_fgivenx, cache=cache,
+                      alpha=0, linewidths=1, ny=ny_kde,
+                      contour_line_levels=[1,2,3,4,5])
         fig.colorbar(cbar, label=r"PDF")

--- a/fgivenx/test/test_drivers.py
+++ b/fgivenx/test/test_drivers.py
@@ -3,6 +3,7 @@ import numpy
 import matplotlib.pyplot as plt
 from fgivenx import plot_contours, plot_lines, plot_dkl
 from fgivenx.drivers import compute_samples, compute_pmf, compute_dkl
+from matplotlib.colors import LogNorm
 
 
 def test_full():
@@ -136,3 +137,56 @@ def test_plotting():
 
         ax_lines.get_shared_x_axes().join(ax_lines, ax_fgivenx, ax_samples)
         fig.set_size_inches(6, 6)
+
+
+def test_histogram():
+    # Model definitions
+    # =================
+    # Define a simple straight line function, parameters theta=(m,c)
+    def f(x, theta):
+        m, c = theta
+        return m * x + c
+
+    numpy.random.seed(1)
+
+    # Posterior samples
+    nsamples = 1000
+    ms = numpy.random.normal(loc=-5, scale=1, size=nsamples)
+    cs = numpy.random.normal(loc=2, scale=1, size=nsamples)
+    samples = numpy.array([(m, c) for m, c in zip(ms, cs)]).copy()
+
+    # Prior samples
+    ms = numpy.random.normal(loc=0, scale=5, size=nsamples)
+    cs = numpy.random.normal(loc=0, scale=5, size=nsamples)
+    prior_samples = numpy.array([(m, c) for m, c in zip(ms, cs)]).copy()
+
+    # Examine the function over a range of x's
+    xmin, xmax = -2, 2
+    nx = 100
+    x = numpy.linspace(xmin, xmax, nx)
+
+    # Set the cache
+    cache = 'cache/test'
+    prior_cache = cache + '_prior'
+
+    # Plotting
+    # ========
+    fig, axes = plt.subplots()
+    ax_fgivenx = axes
+    ax_fgivenx.set_ylabel(r'$P(y|x)$')
+    ax_fgivenx.set_xlabel(r'$x$')
+    cbar = plot_contours(f, x, samples, ax_fgivenx, cache=cache,
+                         histogram=True)
+    plot_contours(f, x, samples, ax_fgivenx, cache=cache, alpha=0,
+                  linewidths=2)
+    fig.colorbar(cbar, label=r"$\sigma$")
+
+    fig, axes = plt.subplots()
+    ax_fgivenx = axes
+    ax_fgivenx.set_ylabel(r'$P(y|x)$')
+    ax_fgivenx.set_xlabel(r'$x$')
+    cbar = plot_contours(f, x, samples, ax_fgivenx, cache=cache,
+                         pdf_histogram=True, histogram=True)
+    plot_contours(f, x, samples, ax_fgivenx, cache=cache, alpha=0,
+                  linewidths=2)
+    fig.colorbar(cbar, label=r"PDF")

--- a/fgivenx/test/test_drivers.py
+++ b/fgivenx/test/test_drivers.py
@@ -138,7 +138,6 @@ def test_plotting():
         ax_lines.get_shared_x_axes().join(ax_lines, ax_fgivenx, ax_samples)
         fig.set_size_inches(6, 6)
 
-
 def test_histogram():
     # Model definitions
     # =================
@@ -150,7 +149,7 @@ def test_histogram():
     numpy.random.seed(1)
 
     # Posterior samples
-    nsamples = 1000
+    nsamples = 100000
     ms = numpy.random.normal(loc=-5, scale=1, size=nsamples)
     cs = numpy.random.normal(loc=2, scale=1, size=nsamples)
     samples = numpy.array([(m, c) for m, c in zip(ms, cs)]).copy()
@@ -163,30 +162,29 @@ def test_histogram():
     # Examine the function over a range of x's
     xmin, xmax = -2, 2
     nx = 100
+    ny = 96
     x = numpy.linspace(xmin, xmax, nx)
 
     # Set the cache
-    cache = 'cache/test'
-    prior_cache = cache + '_prior'
+    for cache in [None, 'cache/test']:
+        # Plotting
+        # ========
+        fig, axes = plt.subplots()
+        ax_fgivenx = axes
+        ax_fgivenx.set_ylabel(r'$P(y|x)$')
+        ax_fgivenx.set_xlabel(r'$x$')
+        cbar = plot_contours(f, x, samples, ax_fgivenx, cache=cache,
+                             histogram=True, ny=10*ny)
+        plot_contours(f, x, samples[::1000], ax_fgivenx, cache=cache, alpha=0,
+                      linewidths=2, ny=ny)
+        fig.colorbar(cbar, label=r"$\sigma$")
 
-    # Plotting
-    # ========
-    fig, axes = plt.subplots()
-    ax_fgivenx = axes
-    ax_fgivenx.set_ylabel(r'$P(y|x)$')
-    ax_fgivenx.set_xlabel(r'$x$')
-    cbar = plot_contours(f, x, samples, ax_fgivenx, cache=cache,
-                         histogram=True)
-    plot_contours(f, x, samples, ax_fgivenx, cache=cache, alpha=0,
-                  linewidths=2)
-    fig.colorbar(cbar, label=r"$\sigma$")
-
-    fig, axes = plt.subplots()
-    ax_fgivenx = axes
-    ax_fgivenx.set_ylabel(r'$P(y|x)$')
-    ax_fgivenx.set_xlabel(r'$x$')
-    cbar = plot_contours(f, x, samples, ax_fgivenx, cache=cache,
-                         pdf_histogram=True, histogram=True)
-    plot_contours(f, x, samples, ax_fgivenx, cache=cache, alpha=0,
-                  linewidths=2)
-    fig.colorbar(cbar, label=r"PDF")
+        fig, axes = plt.subplots()
+        ax_fgivenx = axes
+        ax_fgivenx.set_ylabel(r'$P(y|x)$')
+        ax_fgivenx.set_xlabel(r'$x$')
+        cbar = plot_contours(f, x, samples, ax_fgivenx, cache=cache,
+                             pdf_histogram=True, histogram=True, ny=10*ny)
+        plot_contours(f, x, samples[::1000], ax_fgivenx, cache=cache, alpha=0,
+                      linewidths=2, ny=ny)
+        fig.colorbar(cbar, label=r"PDF")

--- a/fgivenx/test/test_plot.py
+++ b/fgivenx/test/test_plot.py
@@ -15,6 +15,15 @@ def gen_plot_data():
     z = numpy.exp(-((X-0.5)**2+(Y-0.5)**2)/0.01)
     return x, y, z
 
+def gen_interesting_plot_data():
+    numpy.random.seed(0)
+    nx = 100
+    ny = 101
+    x = numpy.linspace(0, 1, nx)
+    y = numpy.linspace(0, 1, ny)
+    X, Y = numpy.meshgrid(x, y)
+    z = numpy.exp(-((Y-X**2)**2)/0.01)
+    return x, y, z
 
 def test_plot():
     x, y, z = gen_plot_data()
@@ -31,6 +40,12 @@ def test_plot_transparent():
     cbar = plot(x, y, z, ax, alpha=0.7)
     assert type(cbar) is matplotlib.contour.QuadContourSet
 
+def test_hist():
+    x, y, z = gen_interesting_plot_data()
+
+    fig, ax = plt.subplots()
+    cbar = plot(x, y, z, ax, histogram=True, colors=matplotlib.pyplot.cm.Oranges)
+    assert type(cbar) is matplotlib.collections.QuadMesh
 
 def test_plot_wrong_argument():
     x, y, z = gen_plot_data()

--- a/fgivenx/test/test_plot.py
+++ b/fgivenx/test/test_plot.py
@@ -15,16 +15,6 @@ def gen_plot_data():
     z = numpy.exp(-((X-0.5)**2+(Y-0.5)**2)/0.01)
     return x, y, z
 
-def gen_interesting_plot_data():
-    numpy.random.seed(0)
-    nx = 100
-    ny = 101
-    x = numpy.linspace(0, 1, nx)
-    y = numpy.linspace(0, 1, ny)
-    X, Y = numpy.meshgrid(x, y)
-    z = numpy.exp(-((Y-X**2)**2)/0.01)
-    return x, y, z
-
 def test_plot():
     x, y, z = gen_plot_data()
 
@@ -40,11 +30,12 @@ def test_plot_transparent():
     cbar = plot(x, y, z, ax, alpha=0.7)
     assert type(cbar) is matplotlib.contour.QuadContourSet
 
-def test_hist():
-    x, y, z = gen_interesting_plot_data()
+def test_histogram():
+    x, y, z = gen_plot_data()
 
     fig, ax = plt.subplots()
-    cbar = plot(x, y, z, ax, histogram=True, colors=matplotlib.pyplot.cm.Oranges)
+    cbar = plot(x, y, z[:-1,:-1], ax, histogram=True,
+        pdf_histogram_norm=matplotlib.colors.LogNorm())
     assert type(cbar) is matplotlib.collections.QuadMesh
 
 def test_plot_wrong_argument():


### PR DESCRIPTION
# Description

Showing a histogram instead of filled contours, like this:
![Figure_1](https://user-images.githubusercontent.com/40799217/131144787-f6e69a29-ece3-4685-89d2-8139d067c15a.png)
![Figure_2](https://user-images.githubusercontent.com/40799217/131144794-043b65ca-b194-44f9-800b-9ce214a2b247.png)
Note that the contour lines are still KDE-generated, but the background is showing a histogram of the PMF (1st plot, converted to "sigmas" as usual) or PDF (2nd plot).

Fixes #14 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Function in `tests/`
- [ ] Use in my projects

Not extensively tested yet, until then [Draft] PR.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Open Questions

- I have to check why the background of the histogram is this shade of bright red, I would expect that large area to be the minimum value (white).

- I wonder if it would be useful or reasonably easy to draw histogram-based contour lines. I imagine it might be quite "blocky" with large bins or quite noisy with small bins without smoothing. And if we used smoothing it would of course be basically a KDE again.
But maybe some blocky contour lines would be helpful in some cases, especially for debugging why contours look the way they do. Not sure how to implement it easily and efficiently though. Could iterate and draw a contour line on top of every histogram block if the block above crosses a contour level boundary (e.g. from 5.1 to 4.9 sigma), though this seems like a rather inefficient implementation.