### PR TITLE
I think the default value for weights is described incorrectly

### DIFF
--- a/fgivenx/_utils.py
+++ b/fgivenx/_utils.py
@@ -28,7 +28,7 @@ def _check_args(logZ, f, x, samples, weights):
 
     # f
     if len(logZ) != len(f):
-        raise ValueError("len(logZ) = %i != len(f)= %i"
+        raise ValueError("len(logZ) = %i != len(f) = %i"
                          % (len(logZ), len(f)))
     for func in f:
         if not callable(func):
@@ -37,7 +37,7 @@ def _check_args(logZ, f, x, samples, weights):
 
     # samples
     if len(logZ) != len(samples):
-        raise ValueError("len(logZ) = %i != len(samples)= %i"
+        raise ValueError("len(logZ) = %i != len(samples) = %i"
                          % (len(logZ), len(samples)))
     samples = [numpy.array(s, dtype='double') for s in samples]
     for s in samples:
@@ -46,7 +46,7 @@ def _check_args(logZ, f, x, samples, weights):
 
     # weights
     if len(logZ) != len(weights):
-        raise ValueError("len(logZ) = %i != len(weights)= %i"
+        raise ValueError("len(logZ) = %i != len(weights) = %i"
                          % (len(logZ), len(weights)))
     weights = [numpy.array(w, dtype='double') if w is not None
                else numpy.ones(len(s), dtype='double')

--- a/fgivenx/drivers.py
+++ b/fgivenx/drivers.py
@@ -79,7 +79,7 @@ def plot_contours(f, x, samples, ax=None, **kwargs):
     weights: 1D array-like, optional
         sample weights (or list of weights), if desired. Should have length
         same as `samples.shape[0]`.
-        Default: `numpy.ones_like(samples)`
+        Default: `numpy.ones(samples.shape[0])`
 
     ny: int, optional
         Resolution of `y` axis.
@@ -162,7 +162,7 @@ def plot_lines(f, x, samples, ax=None, **kwargs):
     weights: 1D array-like, optional
         sample weights (or list of weights), if desired. Should have length
         same as `samples.shape[0]`.
-        Default: `numpy.ones_like(samples)`
+        Default: `numpy.ones(samples.shape[0])`
 
     ntrim: int, optional
         Approximate number of samples to trim down to, if desired. Useful if
@@ -241,7 +241,7 @@ def plot_dkl(f, x, samples, prior_samples, ax=None, **kwargs):
     weights, prior_weights: 1D array-like, optional
         sample weights (or list of weights), if desired. Should have length
         same as `samples.shape[0]`.
-        Default: `numpy.ones_like(samples)`
+        Default: `numpy.ones(samples.shape[0])`
 
     ntrim: int, optional
         Approximate number of samples to trim down to, if desired. Useful if
@@ -311,7 +311,7 @@ def compute_samples(f, x, samples, **kwargs):
     weights: 1D array-like, optional
         sample weights (or list of weights), if desired. Should have length
         same as `samples.shape[0]`.
-        Default: `numpy.ones_like(samples)`
+        Default: `numpy.ones(samples.shape[0])`
 
     ntrim: int, optional
         Approximate number of samples to trim down to, if desired. Useful if
@@ -387,7 +387,7 @@ def compute_pmf(f, x, samples, **kwargs):
     weights: 1D array-like, optional
         sample weights (or list of weights), if desired. Should have length
         same as `samples.shape[0]`.
-        Default: `numpy.ones_like(samples)`
+        Default: `numpy.ones(samples.shape[0])`
 
     ny: int, optional
         Resolution of y axis.
@@ -475,7 +475,7 @@ def compute_dkl(f, x, samples, prior_samples, **kwargs):
     weights, prior_weights: 1D array-like, optional
         sample weights (or list of weights), if desired. Should have length
         same as `samples.shape[0]`.
-        Default: `numpy.ones_like(samples)`
+        Default: `numpy.ones(samples.shape[0])`
 
     ntrim: int, optional
         Approximate number of samples to trim down to, if desired. Useful if


### PR DESCRIPTION
I think the default value for weights is actually numpy.ones(samples.shape[0]), rather than numpy.ones_like(samples) as described in the docstrings in drivers.py