### PR TITLE
Fixing default for contour_line_levels in plot() docstring

### DIFF
--- a/fgivenx/plot.py
+++ b/fgivenx/plot.py
@@ -32,7 +32,7 @@ def plot(x, y, z, ax=None, **kwargs):
         (Default: no smoothing)
 
     contour_line_levels: List[float], optional
-        Contour lines to be plotted.  (Default: [1,2])
+        Contour lines to be plotted.  (Default: [1,2,3])
 
     linewidths: float, optional
         Thickness of contour lines.  (Default: 0.3)


### PR DESCRIPTION
# Description

Fixing incorrect default in doc string for contour_line_levels in plot(). It was set to [1, 2] but is actually [1, 2, 3] in the code.

## Type of change

Documentation update.