### PR TITLE
Auto-publish to PyPI on push to master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,10 +49,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball
@@ -81,10 +81,10 @@ jobs:
     name: test installation from pypi
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install from pypi
         run: pip install fgivenx
       - name: get install version

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,94 @@
+name: Build and push to PyPI on merging to master
+on:
+  push:
+    branches:
+      - master
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.step1.outputs.v }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get version number
+        id: step1
+        run: echo "v=$(grep ':Version:' README.rst | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+  git-tag-and-release:
+    runs-on: ubuntu-latest
+    needs: get-version
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: set version number
+        run: echo "DIST_VERSION=v${{ needs.get-version.outputs.version }}" >> $GITHUB_ENV
+      - name: Create Tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const {DIST_VERSION} = process.env
+            github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/tags/${DIST_VERSION}`,
+                sha: context.sha
+            })
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: "${{ env.DIST_VERSION }}"
+          tag: "${{ env.DIST_VERSION }}"
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  pypi-release:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install pypa/build
+        run: python -m pip install build --user
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  pypi-public:
+    needs:
+      - get-version
+      - pypi-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for PyPi
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: "https://files.pythonhosted.org/packages/source/f/fgivenx/fgivenx-${{ needs.get-version.outputs.version }}.tar.gz"
+          responseCode: 200
+          timeout: 600000
+          interval: 10000
+
+  pypi-build:
+    needs:
+      - pypi-public
+      - get-version
+    name: test installation from pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install from pypi
+        run: pip install fgivenx
+      - name: get install version
+        run: echo "install_version=$(python -c 'import fgivenx; print(fgivenx.__version__)')" >> $GITHUB_ENV
+      - name: fail if versions not matching
+        if: ${{ env.install_version != needs.get-version.outputs.version }}
+        run: exit 1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yaml` mirroring [anesthetic's release workflow](https://github.com/handley-lab/anesthetic/blob/master/.github/workflows/build.yaml)
- On every push to `master`: reads `:Version:` from `README.rst`, tags `vX.Y.Z`, creates a GitHub Release with auto-generated notes, builds sdist + wheel, publishes to PyPI, and verifies the upload by re-installing from PyPI
- fgivenx is already on PyPI (last release 2.4.2); current code is 2.5.0/2.5.1, so first run will publish whatever is on master at merge time

## One-off setup required before this can work
PyPI **trusted publishing** (OIDC, no token):
1. On https://pypi.org/manage/project/fgivenx/settings/publishing/, add a trusted publisher:
   - Owner: `handley-lab`
   - Repository: `fgivenx`
   - Workflow: `build.yaml`
   - Environment: `pypi`
2. Create a GitHub Environment named `pypi` on this repo (Settings → Environments)

No `PYPI_API_TOKEN` secret needed — this is the modern recommended approach and what anesthetic should arguably migrate to as well.

## Notes
- Stripped the AUR and conda jobs from anesthetic's workflow since fgivenx has no AUR/conda packaging set up. Trivial to add later if desired.
- Best merged after #32 so the first auto-release ships the pyproject.toml-based build, but does not conflict with #32 (different files).

## Test plan
- [ ] Configure PyPI trusted publisher + GitHub `pypi` environment
- [ ] Merge #32 first
- [ ] Merge this; confirm a `v2.5.1` tag + GitHub Release appear and fgivenx 2.5.1 lands on PyPI