### PR TITLE
Bump supported Python to 3.10-3.14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,14 +16,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         install: ['.', '.[parallel,progress_bar,getdist_chains]']
         include:
           - os: macos-latest
-            python-version: '3.13'
+            python-version: '3.14'
             install: '.[parallel,progress_bar,getdist_chains]'
           - os: windows-latest
-            python-version: '3.13'
+            python-version: '3.14'
             install: '.[parallel,progress_bar,getdist_chains]'
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,10 +49,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball
@@ -81,10 +81,10 @@ jobs:
     name: test installation from pypi
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install from pypi
         run: pip install fgivenx
       - name: get install version

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ fgivenx: Functional Posterior Plotter
 =====================================
 :fgivenx:  Functional Posterior Plotter 
 :Author: Will Handley
-:Version: 2.5.1
+:Version: 2.5.2
 :Homepage: https://github.com/handley-lab/fgivenx
 :Documentation: http://fgivenx.readthedocs.io/
 
@@ -105,7 +105,7 @@ Dependencies
 =============
 Basic requirements:
 
-* Python 3.9+
+* Python 3.10+
 * `matplotlib <https://pypi.org/project/matplotlib/>`__
 * `numpy <https://pypi.org/project/numpy/>`__
 * `scipy <https://pypi.org/project/scipy/>`__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "fgivenx: Functional Posterior Plotter"
 readme = "README.rst"
 license = { text = "MIT" }
 authors = [{ name = "Will Handley", email = "wh260@cam.ac.uk" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["matplotlib", "numpy", "scipy"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -17,11 +17,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",


### PR DESCRIPTION
## Summary
Aligns fgivenx's Python support window with anesthetic's (3.10–3.14).

- Drops 3.9 (EOL since 2025-10-31)
- Adds 3.14 (released 2025-10-07, supported through 2030-10)
- `requires-python = ">=3.10"`, classifiers updated to match
- CI matrix now 3.10–3.14; macOS/Windows jobs targeted at 3.14
- `.readthedocs.yml` build Python: 3.9 → 3.10
- README dependency line: "Python 3.9+" → "Python 3.10+"
- Version bumped 2.5.1 → 2.5.2

## Why now
With #33 about to land (auto-publish to PyPI on merge to master), every merge ships a release. Better to ship 2.5.2 with a current Python support window than ship 2.5.1 with a stale one.

## Merge ordering
Either order works:
- If #33 merges first: it publishes 2.5.1, then this lands and publishes 2.5.2
- If this merges first: no publish yet, then #33 lands and publishes 2.5.2

## Test plan
- [ ] CI green across the new 3.10–3.14 matrix
- [ ] Once merged + published, `pip install fgivenx==2.5.2` works on Python 3.10–3.14