### PR TITLE
restrict matplotlib>=3.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ fgivenx: Functional Posterior Plotter
 =====================================
 :fgivenx:  Functional Posterior Plotter 
 :Author: Will Handley
-:Version: 2.5.2
+:Version: 2.5.3
 :Homepage: https://github.com/handley-lab/fgivenx
 :Documentation: http://fgivenx.readthedocs.io/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.rst"
 license = { text = "MIT" }
 authors = [{ name = "Will Handley", email = "wh260@cam.ac.uk" }]
 requires-python = ">=3.10"
-dependencies = ["matplotlib", "numpy", "scipy"]
+dependencies = ["matplotlib>=3.8", "numpy", "scipy"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
# Description

Restrict to matplotlib>=3.8.0 due to api change. We (I) updated the fgivenx api in #26, but didn't restrict the setup.py (as it was back then) accordingly.

Somewhat helps wth #35 but the feedstock will still need fiddling

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

I guess technically this is a breaking change, though it feels more like a broken change. smh my head


